### PR TITLE
Changing MapperFactory to invoke a ConstructorInfo instead of Activator

### DIFF
--- a/src/NanoBuilder/NanoBuilder.UnitTests/MapperFactoryTests.cs
+++ b/src/NanoBuilder/NanoBuilder.UnitTests/MapperFactoryTests.cs
@@ -60,7 +60,7 @@ namespace NanoBuilder.UnitTests
 
          Action create = () => mapperFactory.Create<FaultyMapper>();
 
-         create.ShouldThrow<NanoBuilderException>().Which.InnerException.Should().BeOfType<MissingMethodException>();
+         create.ShouldThrow<NanoBuilderException>();
       }
    }
 }


### PR DESCRIPTION
This lets us not use the BindingFlags which doesn't jive with netstandard versions.