### PR TITLE
Ditching uses of SerializationInfo in protected Exception constructors

### DIFF
--- a/src/NanoBuilder/NanoBuilder/AmbiguousConstructorException.cs
+++ b/src/NanoBuilder/NanoBuilder/AmbiguousConstructorException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace NanoBuilder
 {
@@ -37,24 +36,6 @@ namespace NanoBuilder
       /// (Nothing in Visual Basic) if no inner exception is specified.</param>
       public AmbiguousConstructorException( string message, Exception innerException )
          : base( message, innerException )
-      {
-      }
-
-      /// <summary>
-      /// Initializes a new instance of the AmbiguousConstructorException class with serialized data.
-      /// </summary>
-      /// <param name="info">
-      /// The System.Runtime.Serialization.SerializationInfo that holds the serialized
-      /// object data about the exception being thrown.
-      /// </param>
-      /// <param name="context">
-      /// The System.Runtime.Serialization.StreamingContext that contains contextual information
-      /// about the source or destination.
-      /// </param>
-      /// <exception cref="ArgumentNullException">The info parameter is null.</exception>
-      /// <exception cref="SerializationException">The class name is null or System.Exception.HResult is zero (0).</exception>
-      protected AmbiguousConstructorException( SerializationInfo info, StreamingContext context )
-         : base( info, context )
       {
       }
    }

--- a/src/NanoBuilder/NanoBuilder/MapperException.cs
+++ b/src/NanoBuilder/NanoBuilder/MapperException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace NanoBuilder
 {
@@ -37,24 +36,6 @@ namespace NanoBuilder
       /// (Nothing in Visual Basic) if no inner exception is specified.</param>
       public MapperException( string message, Exception innerException )
          : base( message, innerException )
-      {
-      }
-
-      /// <summary>
-      /// Initializes a new instance of the MapperException class with serialized data.
-      /// </summary>
-      /// <param name="info">
-      /// The System.Runtime.Serialization.SerializationInfo that holds the serialized
-      /// object data about the exception being thrown.
-      /// </param>
-      /// <param name="context">
-      /// The System.Runtime.Serialization.StreamingContext that contains contextual information
-      /// about the source or destination.
-      /// </param>
-      /// <exception cref="ArgumentNullException">The info parameter is null.</exception>
-      /// <exception cref="SerializationException">The class name is null or System.Exception.HResult is zero (0).</exception>
-      protected MapperException( SerializationInfo info, StreamingContext context )
-         : base( info, context )
       {
       }
    }

--- a/src/NanoBuilder/NanoBuilder/NanoBuilderException.cs
+++ b/src/NanoBuilder/NanoBuilder/NanoBuilderException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace NanoBuilder
 {
@@ -35,24 +34,6 @@ namespace NanoBuilder
       /// (Nothing in Visual Basic) if no inner exception is specified.</param>
       public NanoBuilderException( string message, Exception innerException )
          : base( message, innerException )
-      {
-      }
-
-      /// <summary>
-      /// Initializes a new instance of the NanoBuilderException class with serialized data.
-      /// </summary>
-      /// <param name="info">
-      /// The System.Runtime.Serialization.SerializationInfo that holds the serialized
-      /// object data about the exception being thrown.
-      /// </param>
-      /// <param name="context">
-      /// The System.Runtime.Serialization.StreamingContext that contains contextual information
-      /// about the source or destination.
-      /// </param>
-      /// <exception cref="ArgumentNullException">The info parameter is null.</exception>
-      /// <exception cref="SerializationException">The class name is null or System.Exception.HResult is zero (0).</exception>
-      protected NanoBuilderException( SerializationInfo info, StreamingContext context )
-         : base( info, context )
       {
       }
    }

--- a/src/NanoBuilder/NanoBuilder/ParameterMappingException.cs
+++ b/src/NanoBuilder/NanoBuilder/ParameterMappingException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace NanoBuilder
 {
@@ -37,24 +36,6 @@ namespace NanoBuilder
       /// (Nothing in Visual Basic) if no inner exception is specified.</param>
       public ParameterMappingException( string message, Exception innerException )
          : base( message, innerException )
-      {
-      }
-
-      /// <summary>
-      /// Initializes a new instance of the ParameterMappingException class with serialized data.
-      /// </summary>
-      /// <param name="info">
-      /// The System.Runtime.Serialization.SerializationInfo that holds the serialized
-      /// object data about the exception being thrown.
-      /// </param>
-      /// <param name="context">
-      /// The System.Runtime.Serialization.StreamingContext that contains contextual information
-      /// about the source or destination.
-      /// </param>
-      /// <exception cref="ArgumentNullException">The info parameter is null.</exception>
-      /// <exception cref="SerializationException">The class name is null or System.Exception.HResult is zero (0).</exception>
-      protected ParameterMappingException( SerializationInfo info, StreamingContext context )
-         : base( info, context )
       {
       }
    }

--- a/src/NanoBuilder/NanoBuilder/TypeMapperException.cs
+++ b/src/NanoBuilder/NanoBuilder/TypeMapperException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace NanoBuilder
 {
@@ -36,24 +35,6 @@ namespace NanoBuilder
       /// (Nothing in Visual Basic) if no inner exception is specified.</param>
       public TypeMapperException( string message, Exception innerException )
          : base( message, innerException )
-      {
-      }
-
-      /// <summary>
-      /// Initializes a new instance of the TypeMapperException class with serialized data.
-      /// </summary>
-      /// <param name="info">
-      /// The System.Runtime.Serialization.SerializationInfo that holds the serialized
-      /// object data about the exception being thrown.
-      /// </param>
-      /// <param name="context">
-      /// The System.Runtime.Serialization.StreamingContext that contains contextual information
-      /// about the source or destination.
-      /// </param>
-      /// <exception cref="ArgumentNullException">The info parameter is null.</exception>
-      /// <exception cref="SerializationException">The class name is null or System.Exception.HResult is zero (0).</exception>
-      protected TypeMapperException( SerializationInfo info, StreamingContext context )
-         : base( info, context )
       {
       }
    }


### PR DESCRIPTION
I know FxCop gets on us about this, but it doesn't jive with netstandard, so we're ditching it for now. Not sure I've even ever used this thing anyway.