### PR TITLE
Fixing URLs to point to NanoBuilder

### DIFF
--- a/NanoBuilder.nuspec
+++ b/NanoBuilder.nuspec
@@ -5,8 +5,8 @@
     <version>0.9.2-alpha</version>
     <authors>Alex Novak</authors>
     <owners>alexwnovak</owners>
-    <licenseUrl>https://github.com/alexwnovak/NanoBuilder/blob/master/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/alexwnovak/NanoBuilder</projectUrl>
+    <licenseUrl>https://github.com/NanoBuilder/NanoBuilder/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/NanoBuilder/NanoBuilder</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A modest way to build objects</description>
     <releaseNotes>Version 0.9.2-alpha


### PR DESCRIPTION
Must've lost the right values when bringing the repo over to the new URL.