### PR TITLE
Moving all language/fluent syntax flow types into a Flow namespace

### DIFF
--- a/src/NanoBuilder/NanoBuilder.UnitTests/ParameterComposerTests.cs
+++ b/src/NanoBuilder/NanoBuilder.UnitTests/ParameterComposerTests.cs
@@ -2,6 +2,7 @@
 using Xunit;
 using FluentAssertions;
 using Moq;
+using NanoBuilder.Flow;
 using NanoBuilder.Stubs;
 
 namespace NanoBuilder.UnitTests

--- a/src/NanoBuilder/NanoBuilder/AmbiguousConstructorException.cs
+++ b/src/NanoBuilder/NanoBuilder/AmbiguousConstructorException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using NanoBuilder.Flow;
 
 namespace NanoBuilder
 {

--- a/src/NanoBuilder/NanoBuilder/Flow/IFullParameterComposer.cs
+++ b/src/NanoBuilder/NanoBuilder/Flow/IFullParameterComposer.cs
@@ -1,4 +1,4 @@
-﻿namespace NanoBuilder
+﻿namespace NanoBuilder.Flow
 {
    /// <summary>
    /// A class that can configure constructor parameters.

--- a/src/NanoBuilder/NanoBuilder/Flow/IMappedInterfaceConstraint.cs
+++ b/src/NanoBuilder/NanoBuilder/Flow/IMappedInterfaceConstraint.cs
@@ -1,4 +1,4 @@
-﻿namespace NanoBuilder
+﻿namespace NanoBuilder.Flow
 {
    /// <summary>
    /// This allows you decide how interfaces types can be initialized by default.

--- a/src/NanoBuilder/NanoBuilder/Flow/ParameterComposer.cs
+++ b/src/NanoBuilder/NanoBuilder/Flow/ParameterComposer.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using System.Reflection;
 
-namespace NanoBuilder
+namespace NanoBuilder.Flow
 {
    internal class FullParameterComposer<T> : IFullParameterComposer<T>
    {

--- a/src/NanoBuilder/NanoBuilder/IParameterComposer.cs
+++ b/src/NanoBuilder/NanoBuilder/IParameterComposer.cs
@@ -1,3 +1,5 @@
+using NanoBuilder.Flow;
+
 namespace NanoBuilder
 {
    /// <summary>

--- a/src/NanoBuilder/NanoBuilder/ITypeMapper.cs
+++ b/src/NanoBuilder/NanoBuilder/ITypeMapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using NanoBuilder.Flow;
 
 namespace NanoBuilder
 {

--- a/src/NanoBuilder/NanoBuilder/MapperException.cs
+++ b/src/NanoBuilder/NanoBuilder/MapperException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using NanoBuilder.Flow;
 
 namespace NanoBuilder
 {

--- a/src/NanoBuilder/NanoBuilder/ObjectBuilder.cs
+++ b/src/NanoBuilder/NanoBuilder/ObjectBuilder.cs
@@ -1,4 +1,6 @@
-﻿namespace NanoBuilder
+﻿using NanoBuilder.Flow;
+
+namespace NanoBuilder
 {
    /// <summary>
    /// Provides a way of creating objects by specifying arguments for the constructor. Relevant arguments

--- a/src/NanoBuilder/NanoBuilder/ParameterMappingException.cs
+++ b/src/NanoBuilder/NanoBuilder/ParameterMappingException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using NanoBuilder.Flow;
 
 namespace NanoBuilder
 {


### PR DESCRIPTION
Note that this doesn't affect the end-user in 99% of scenarios, since this is a fluent syntax. Meaning, they don't directly reference these flow types by name (which would require importing the namespace). Since we chain them together in calls, we don't need to know their name or namespace.